### PR TITLE
Make the client ID optional and support API secret

### DIFF
--- a/berbix.gemspec
+++ b/berbix.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'berbix'
-  s.version = '0.0.5'
+  s.version = '0.0.6'
   s.date = '2019-06-05'
   s.summary = 'Berbix Ruby SDK'
   s.description = 'Backend SDKs to interact with the Berbix Verify API endpoints.'

--- a/examples/transactions.rb
+++ b/examples/transactions.rb
@@ -2,8 +2,7 @@ require 'pp'
 require_relative '../lib/berbix'
 
 client = Berbix::Client.new(
-  client_id: ENV['BERBIX_DEMO_CLIENT_ID'],
-  client_secret: ENV['BERBIX_DEMO_CLIENT_SECRET'],
+  api_secret: ENV['BERBIX_DEMO_CLIENT_SECRET'],
   api_host: ENV['BERBIX_DEMO_API_HOST'],
 )
 

--- a/lib/berbix.rb
+++ b/lib/berbix.rb
@@ -70,16 +70,12 @@ module Berbix
 
   class Client
     def initialize(opts={})
-      @client_id = opts[:client_id]
-      @client_secret = opts[:client_secret]
+      @api_secret = opts[:api_secret] || opts[:client_secret]
       @api_host = api_host(opts)
       @http_client = opts[:http_client] || NetHTTPClient.new
 
-      if @client_id.nil?
-        raise ':client_id must be provided when instantiating Berbix client'
-      end
-      if @client_secret.nil?
-        raise ':client_secret must be provided when instantiating Berbix client'
+      if @api_secret.nil?
+        raise ':api_secret must be provided when instantiating Berbix client'
       end
     end
 
@@ -182,7 +178,7 @@ module Berbix
     end
 
     def auth
-      { user: @client_id, pass: @client_secret }
+      { user: @api_secret, pass: '' }
     end
 
     def api_host(opts)


### PR DESCRIPTION
Per the Berbix API updates, this updated backend SDK removes the requirement for the client ID to be specified in the ruby SDK. This ensures backwards compatibility with existing integrations with the SDK.