### PR TITLE
Adds support for specifying a timeout.

### DIFF
--- a/lib/berbix.rb
+++ b/lib/berbix.rb
@@ -14,8 +14,11 @@ module Berbix
 
   class NetHTTPClient < HTTPClient
     attr_reader :read_timeout
+    attr_reader :open_timeout
 
     def initialize(opts={})
+      # Sets the defaults to align with the Net::HTTP defaults
+      @open_timeout = opts[:open_timeout] || 60
       @read_timeout = opts[:read_timeout] || 60
     end
 
@@ -40,6 +43,7 @@ module Berbix
       cli = Net::HTTP.new(uri.host, uri.port).tap do |http|
         http.use_ssl = true
         http.read_timeout = read_timeout
+        http.open_timeout = open_timeout
       end
       res = cli.request(req)
       code = res.code.to_i

--- a/lib/berbix.rb
+++ b/lib/berbix.rb
@@ -16,7 +16,7 @@ module Berbix
     attr_reader :read_timeout
 
     def initialize(opts={})
-      @read_timeout = opts[:read_timeout] || 10
+      @read_timeout = opts[:read_timeout] || 60
     end
 
     def request(method, url, headers, opts={})

--- a/lib/berbix.rb
+++ b/lib/berbix.rb
@@ -13,6 +13,12 @@ module Berbix
   end
 
   class NetHTTPClient < HTTPClient
+    attr_reader :read_timeout
+
+    def initialize(opts={})
+      @read_timeout = opts[:read_timeout] || 10
+    end
+
     def request(method, url, headers, opts={})
       uri = URI(url)
       klass = if method == :post
@@ -33,6 +39,7 @@ module Berbix
       end
       cli = Net::HTTP.new(uri.host, uri.port).tap do |http|
         http.use_ssl = true
+        http.read_timeout = read_timeout
       end
       res = cli.request(req)
       code = res.code.to_i


### PR DESCRIPTION
Adds support for specifying read and open timeouts in the ruby client. The default is currently set to 60 seconds in the Net::HTTP package, so the defaults align with that.