### PR TITLE
Add support for hosted_options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Supported options:
 - `phone` - Previously verified phone number for a user.
 - `customer_uid` - An ID or identifier for the user in your system.
 - `template_key` - The template key for this transaction.
+- `hosted_options` - Optional configuration object for creating hosted transactions.
+  - `completion_email` - Email address to which completion alerts will be sent for this transaction.
 
 ##### `fetch_transaction(tokens: Tokens): object`
 
@@ -121,6 +123,10 @@ This is the long-lived token that allows you to create new tokens after the shor
 ##### `transaction_id: number`
 
 The internal Berbix ID number associated with the transaction.
+
+##### `hosted_url: string`
+
+Represents the hosted transaction URL. This value will only be set when creating a transaction if the hosted_options field is set.
 
 ##### `expiry: Date`
 

--- a/lib/berbix.rb
+++ b/lib/berbix.rb
@@ -57,15 +57,16 @@ module Berbix
   end
 
   class Tokens
-    attr_reader :access_token, :client_token, :refresh_token, :expiry, :transaction_id, :user_id
+    attr_reader :access_token, :client_token, :refresh_token, :expiry, :transaction_id, :user_id, :hosted_url
 
-    def initialize(refresh_token, access_token=nil, client_token=nil, expiry=nil, transaction_id=nil)
+    def initialize(refresh_token, access_token=nil, client_token=nil, expiry=nil, transaction_id=nil, hosted_url=nil)
       @refresh_token = refresh_token
       @access_token = access_token
       @client_token = client_token
       @expiry = expiry
       @transaction_id = transaction_id
       @user_id = transaction_id
+      @hosted_url = hosted_url
     end
 
     def refresh!(access_token, client_token, expiry, transaction_id)
@@ -102,6 +103,7 @@ module Berbix
       payload[:phone] = opts[:phone] unless opts[:phone].nil?
       payload[:customer_uid] = opts[:customer_uid].to_s unless opts[:customer_uid].nil?
       payload[:template_key] = opts[:template_key] unless opts[:template_key].nil?
+      payload[:hosted_options] = opts[:hosted_options] unless opts[:hosted_options].nil?
       fetch_tokens('/v0/transactions', payload)
     end
 
@@ -209,7 +211,8 @@ module Berbix
         result['access_token'],
         result['client_token'],
         Time.now + result['expires_in'],
-        result['transaction_id'])
+        result['transaction_id'],
+        result['hosted_url'])
     end
 
     def auth


### PR DESCRIPTION
The Berbix python library supports this (https://github.com/berbix/berbix-python), since I need this for the ruby gem I figured I'd create a PR for it.