### PR TITLE
Add response object to Token and move hosted_url into that to be cons…

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,13 @@ This is the long-lived token that allows you to create new tokens after the shor
 
 The internal Berbix ID number associated with the transaction.
 
-##### `hosted_url: string`
+##### `response: object`
 
-Represents the hosted transaction URL. This value will only be set when creating a transaction if the hosted_options field is set.
+The raw response object. This may include some non-token related fields.
+
+###### `hosted_url: string`
+
+This is a member of the response object. Represents the hosted transaction URL. This value will only be set when creating a transaction if the `hosted_options` field is set.
 
 ##### `expiry: Date`
 

--- a/lib/berbix.rb
+++ b/lib/berbix.rb
@@ -57,16 +57,16 @@ module Berbix
   end
 
   class Tokens
-    attr_reader :access_token, :client_token, :refresh_token, :expiry, :transaction_id, :user_id, :hosted_url
+    attr_reader :access_token, :client_token, :refresh_token, :expiry, :transaction_id, :user_id, :response
 
-    def initialize(refresh_token, access_token=nil, client_token=nil, expiry=nil, transaction_id=nil, hosted_url=nil)
+    def initialize(refresh_token, access_token=nil, client_token=nil, expiry=nil, transaction_id=nil, response=nil)
       @refresh_token = refresh_token
       @access_token = access_token
       @client_token = client_token
       @expiry = expiry
       @transaction_id = transaction_id
       @user_id = transaction_id
-      @hosted_url = hosted_url
+      @response = response
     end
 
     def refresh!(access_token, client_token, expiry, transaction_id)
@@ -212,7 +212,7 @@ module Berbix
         result['client_token'],
         Time.now + result['expires_in'],
         result['transaction_id'],
-        result['hosted_url'])
+        result)
     end
 
     def auth


### PR DESCRIPTION
Add `response` object to `Token` and move `hosted_url` into that to be consistent with the Berbix Python library.

The hosted url can be access like this: `@transaction_tokens.response["hosted_url"]`.

In addition to being consistent with the Berbix Python library, this approach has the added benefit of not _always_ showing the `hosted_url` attribute on the `Token` object.  This may make it more clear to users of this gem that `hosted_url` is not always included as part of a `Token` and only returned when specifically requested as part of that flow.

/cc @philipkocanda